### PR TITLE
Add neutral_venue option to exclude home advantage per match

### DIFF
--- a/docs/models/overview.rst
+++ b/docs/models/overview.rst
@@ -117,8 +117,8 @@ Common Methods
 Every model implements the following core methods:
 
 - ``fit(minimizer_options)``: Train the model using your dataset.
-- ``predict(home_team, away_team, max_goals, normalize)``: Predict scoreline probabilities for a given fixture.
-- ``predict_many(home_teams, away_teams, max_goals, normalize)``: Predict scoreline probabilities for multiple fixtures in one call.
+- ``predict(home_team, away_team, max_goals, normalize, neutral_venue)``: Predict scoreline probabilities for a given fixture.
+- ``predict_many(home_teams, away_teams, max_goals, normalize, neutral_venue)``: Predict scoreline probabilities for multiple fixtures in one call.
 - ``get_params()``: Retrieve the model's fitted parameters.
 - ``save(filepath)``: Save the model to disk as a pickled file.
 - ``load(filepath)``: Load the saved model.
@@ -196,6 +196,54 @@ Example
        weights=weights
    )
    model.fit()
+
+Neutral Venue Matches
+=====================
+
+Some fixtures are played at a neutral venue where neither side enjoys a home
+advantage - most commonly in tournaments such as the World Cup or continental
+cups. By default every match is treated as a home/away fixture. The optional
+``neutral_venue`` argument lets you exclude home advantage from those matches.
+
+At **training time**, ``neutral_venue`` is a per-match array of ``0``/``1``
+values (``1`` marks a neutral-venue match). Neutral matches contribute nothing
+to the home advantage estimate, so it is learned only from genuine home games:
+
+.. code-block:: python
+
+   from penaltyblog.models import PoissonGoalsModel
+
+   model = PoissonGoalsModel(
+       train["goals_home"],
+       train["goals_away"],
+       train["team_home"],
+       train["team_away"],
+       neutral_venue=train["neutral_venue"],  # 0/1 per match
+   )
+   model.fit()
+
+If **every** training match is neutral the home advantage parameter is not
+identifiable; in that case it is pinned to ``0`` after fitting so it cannot
+leak an arbitrary value into predictions.
+
+At **prediction time**, pass ``neutral_venue`` to drop home advantage for the
+fixture being predicted:
+
+.. code-block:: python
+
+   # Single fixture played at a neutral venue
+   pred = model.predict("Brazil", "Croatia", neutral_venue=True)
+
+   # Multiple fixtures: a per-fixture 0/1 array
+   batch = model.predict_many(
+       ["Brazil", "France"],
+       ["Croatia", "England"],
+       neutral_venue=[1, 0],
+   )
+
+``neutral_venue`` defaults to non-neutral everywhere (``None``), so existing
+code that omits it is unaffected. It is supported by every goal model,
+including the Bayesian models.
 
 Rich Probability Outputs for Betting and Analytics
 ==================================================

--- a/penaltyblog/bayes/likelihood.pyx
+++ b/penaltyblog/bayes/likelihood.pyx
@@ -190,7 +190,6 @@ def bayesian_predict_c(
     When neutral_venue is 1, home advantage is excluded from the prediction.
     """
     cdef int n_samples = trace.shape[0]
-    cdef int n_params = trace.shape[1]
 
     cdef int dim = max_goals
     cdef double[:, ::1] avg_matrix = np.zeros((dim, dim), dtype=np.float64)
@@ -209,8 +208,12 @@ def bayesian_predict_c(
             att_a = trace[s, away_idx]
             def_h = trace[s, n_teams + home_idx]
             def_a = trace[s, n_teams + away_idx]
-            hfa   = trace[s, n_params - 2]
-            rho   = trace[s, n_params - 1]
+            # hfa and rho sit right after the 2*n_teams attack/defence params.
+            # Indexing relative to n_teams (not the trace width) keeps this
+            # correct for the hierarchical model, whose trace has trailing
+            # sigma parameters.
+            hfa   = trace[s, 2 * n_teams]
+            rho   = trace[s, 2 * n_teams + 1]
 
             # Lambdas (home advantage excluded at a neutral venue)
             lambda_h = exp(fmin(MAX_EXP_VAL, hfa * (1 - neutral_venue) + att_h + def_a))

--- a/penaltyblog/bayes/likelihood.pyx
+++ b/penaltyblog/bayes/likelihood.pyx
@@ -180,11 +180,14 @@ def bayesian_predict_c(
     int home_idx,
     int away_idx,
     int n_teams,
-    int max_goals
+    int max_goals,
+    int neutral_venue
 ):
     """
     Computes the Posterior Predictive probability matrix.
     Averages the Dixon-Coles matrix over all MCMC samples.
+
+    When neutral_venue is 1, home advantage is excluded from the prediction.
     """
     cdef int n_samples = trace.shape[0]
     cdef int n_params = trace.shape[1]
@@ -209,8 +212,8 @@ def bayesian_predict_c(
             hfa   = trace[s, n_params - 2]
             rho   = trace[s, n_params - 1]
 
-            # Lambdas
-            lambda_h = exp(fmin(MAX_EXP_VAL, hfa + att_h + def_a))
+            # Lambdas (home advantage excluded at a neutral venue)
+            lambda_h = exp(fmin(MAX_EXP_VAL, hfa * (1 - neutral_venue) + att_h + def_a))
             lambda_h = fmax(MIN_LAMBDA, lambda_h)
 
             lambda_a = exp(fmin(MAX_EXP_VAL, att_a + def_h))

--- a/penaltyblog/bayes/likelihood.pyx
+++ b/penaltyblog/bayes/likelihood.pyx
@@ -26,6 +26,7 @@ cdef double dixon_coles_neg_ll_c(
     double[:] weights,
     long[:] home_indices,
     long[:] away_indices,
+    long[:] neutral_venue,
     double[:] attack,
     double[:] defence,
     double hfa,
@@ -43,7 +44,8 @@ cdef double dixon_coles_neg_ll_c(
         # Expected goals
         # 1. Clip exponent to prevent overflow in exp()
         # 2. Clip result to prevent underflow in log() (min lambda)
-        lambda_home = exp(fmin(MAX_EXP_VAL, hfa + attack[home_idx] + defence[away_idx]))
+        # Home advantage is excluded for matches played at a neutral venue.
+        lambda_home = exp(fmin(MAX_EXP_VAL, hfa * (1 - neutral_venue[i]) + attack[home_idx] + defence[away_idx]))
         lambda_home = fmax(MIN_LAMBDA, lambda_home)
 
         lambda_away = exp(fmin(MAX_EXP_VAL, attack[away_idx] + defence[home_idx]))
@@ -87,10 +89,12 @@ def football_log_prob_wrapper(double[:] params, object data):
     cdef long[:] goals_home = data['goals_home']
     cdef long[:] goals_away = data['goals_away']
     cdef double[:] weights = data['weights']
+    cdef long[:] neutral_venue = data['neutral_venue']
     cdef int n_teams = data['n_teams']
 
     return _bayesian_log_prob_c(
-        params, home_idx, away_idx, goals_home, goals_away, weights, n_teams
+        params, home_idx, away_idx, goals_home, goals_away, weights,
+        neutral_venue, n_teams
     )
 
 cdef double _bayesian_log_prob_c(
@@ -100,6 +104,7 @@ cdef double _bayesian_log_prob_c(
     long[:] goals_home,
     long[:] goals_away,
     double[:] weights,
+    long[:] neutral_venue,
     int n_teams
 ) nogil:
     cdef double log_prob = 0.0
@@ -158,7 +163,7 @@ cdef double _bayesian_log_prob_c(
     # --- 3. LIKELIHOOD ---
     cdef double neg_ll = dixon_coles_neg_ll_c(
         goals_home, goals_away, weights,
-        home_idx, away_idx, attack, defense, hfa, rho
+        home_idx, away_idx, neutral_venue, attack, defense, hfa, rho
     )
 
     return log_prob - neg_ll
@@ -266,10 +271,12 @@ def hierarchical_log_prob_wrapper(double[:] params, object data):
     cdef long[:] goals_home = data['goals_home']
     cdef long[:] goals_away = data['goals_away']
     cdef double[:] weights = data['weights']
+    cdef long[:] neutral_venue = data['neutral_venue']
     cdef int n_teams = data['n_teams']
 
     return _hierarchical_log_prob_c(
-        params, home_idx, away_idx, goals_home, goals_away, weights, n_teams
+        params, home_idx, away_idx, goals_home, goals_away, weights,
+        neutral_venue, n_teams
     )
 
 cdef double _hierarchical_log_prob_c(
@@ -279,6 +286,7 @@ cdef double _hierarchical_log_prob_c(
     long[:] goals_home,
     long[:] goals_away,
     double[:] weights,
+    long[:] neutral_venue,
     int n_teams
 ) nogil:
     cdef double log_prob = 0.0
@@ -325,7 +333,7 @@ cdef double _hierarchical_log_prob_c(
 
     cdef double neg_ll = dixon_coles_neg_ll_c(
         goals_home, goals_away, weights,
-        home_idx, away_idx, attack, defense, hfa, rho
+        home_idx, away_idx, neutral_venue, attack, defense, hfa, rho
     )
 
     return log_prob - neg_ll

--- a/penaltyblog/models/base_bayesian_model.py
+++ b/penaltyblog/models/base_bayesian_model.py
@@ -61,6 +61,23 @@ class BaseBayesianModel(BaseGoalsModel):
 
         self.team_map = self.team_to_idx
 
+    def _zero_home_advantage_if_all_neutral(self):
+        """
+        Extend the base behaviour for Bayesian models.
+
+        Bayesian prediction integrates over the posterior trace, not the fitted
+        parameter vector, so the home advantage column of the trace must also be
+        zeroed when every training match is neutral — otherwise prediction would
+        still draw a non-zero home advantage from the (data-free) prior.
+        """
+        super()._zero_home_advantage_if_all_neutral()
+        if (
+            self.trace is not None
+            and self.neutral_venue.size
+            and bool(np.all(self.neutral_venue == 1))
+        ):
+            self.trace[:, self._get_tail_param_indices()["home_advantage"]] = 0.0
+
     def _map_trace_to_dict(self) -> None:
         """
         Helper to convert raw matrix to user-friendly dict.

--- a/penaltyblog/models/base_bayesian_model.py
+++ b/penaltyblog/models/base_bayesian_model.py
@@ -6,7 +6,12 @@ import pandas as pd
 from penaltyblog.bayes.diagnostics import compute_diagnostics
 from penaltyblog.bayes.sampler_api import EnsembleSampler
 from penaltyblog.models.base_model import BaseGoalsModel
-from penaltyblog.models.custom_types import GoalInput, TeamInput, WeightInput
+from penaltyblog.models.custom_types import (
+    GoalInput,
+    NeutralVenueInput,
+    TeamInput,
+    WeightInput,
+)
 
 
 class BaseBayesianModel(BaseGoalsModel):
@@ -25,6 +30,7 @@ class BaseBayesianModel(BaseGoalsModel):
         teams_home: TeamInput,
         teams_away: TeamInput,
         weights: WeightInput = None,
+        neutral_venue: NeutralVenueInput = None,
     ):
         """
         Initialize a Bayesian football model.
@@ -41,8 +47,13 @@ class BaseBayesianModel(BaseGoalsModel):
             Names of away teams for each match.
         weights : WeightInput, optional
             Match weights (e.g., from time decay). If None, all matches are weighted equally.
+        neutral_venue : NeutralVenueInput, optional
+            Per-match flag (0/1) marking matches played at a neutral venue. When 1,
+            home advantage is excluded for that match.
         """
-        super().__init__(goals_home, goals_away, teams_home, teams_away, weights)
+        super().__init__(
+            goals_home, goals_away, teams_home, teams_away, weights, neutral_venue
+        )
 
         self.trace: Optional[np.ndarray] = None
         self.trace_dict: Optional[Dict[str, np.ndarray]] = None

--- a/penaltyblog/models/base_model.py
+++ b/penaltyblog/models/base_model.py
@@ -29,6 +29,31 @@ def _get_cython_long_dtype():
         return np.int64
 
 
+def _coerce_neutral_venue(neutral_venue, n: int) -> np.ndarray:
+    """
+    Validate a neutral_venue flag array and convert it to the Cython long dtype.
+
+    `None` is treated as every entry being non-neutral (all zeros).
+
+    Raises
+    ------
+    ValueError
+        If the array length does not match `n`, or if it holds values other
+        than 0 or 1.
+    """
+    dtype = _get_cython_long_dtype()
+    if neutral_venue is None:
+        return np.zeros(n, dtype=dtype, order="C")
+    arr = np.asarray(neutral_venue, dtype=dtype, order="C")
+    if len(arr) != n:
+        raise ValueError(
+            "neutral_venue array must have the same length as the number of matches."
+        )
+    if ((arr != 0) & (arr != 1)).any():
+        raise ValueError("neutral_venue entries must be 0 or 1.")
+    return arr
+
+
 class BaseGoalsModel(ABC):
     """
     Base class for football (soccer) goals prediction models.
@@ -102,18 +127,7 @@ class BaseGoalsModel(ABC):
                     "Weights array must have the same length as the number of matches."
                 )
 
-        if neutral_venue is None:
-            self.neutral_venue = np.zeros(n_matches, dtype=cython_long_dtype, order="C")
-        else:
-            self.neutral_venue = np.asarray(
-                neutral_venue, dtype=cython_long_dtype, order="C"
-            )
-            if len(self.neutral_venue) != n_matches:
-                raise ValueError(
-                    "neutral_venue array must have the same length as the number of matches."
-                )
-            if ((self.neutral_venue != 0) & (self.neutral_venue != 1)).any():
-                raise ValueError("neutral_venue entries must be 0 or 1.")
+        self.neutral_venue = _coerce_neutral_venue(neutral_venue, n_matches)
 
         self._validate_inputs(n_matches)
         self._setup_teams()
@@ -271,6 +285,18 @@ class BaseGoalsModel(ABC):
         self.loglikelihood = self._res["fun"] * -1
         self.aic = -2 * self.loglikelihood + 2 * self.n_params
         self.fitted = True
+        self._zero_home_advantage_if_all_neutral()
+
+    def _zero_home_advantage_if_all_neutral(self):
+        """
+        Pin home advantage to 0 when every training match is at a neutral venue.
+
+        With an all-neutral dataset the home advantage term drops out of the
+        likelihood entirely, leaving the parameter unidentified — the fit could
+        return any value. Forcing it to 0 keeps it from leaking into predictions.
+        """
+        if self.neutral_venue.size and bool(np.all(self.neutral_venue == 1)):
+            self._params[self._get_tail_param_indices()["home_advantage"]] = 0.0
 
     @abstractmethod
     def fit(self, minimizer_options: Optional[dict] = None):
@@ -366,6 +392,7 @@ class BaseGoalsModel(ABC):
         away_team: str,
         max_goals: int = 15,
         normalize: bool = True,
+        neutral_venue: bool = False,
     ):
         """
         Predict outcome probabilities for a given fixture.
@@ -380,6 +407,9 @@ class BaseGoalsModel(ABC):
             Maximum goals per team to consider.
         normalize : bool, default True
             Whether to normalise the probability grid.
+        neutral_venue : bool, default False
+            If True, the fixture is treated as played at a neutral venue and
+            home advantage is excluded from the prediction.
 
         Returns
         -------
@@ -387,7 +417,9 @@ class BaseGoalsModel(ABC):
             Probability grid object for the match.
         """
         home_idx, away_idx = self._predict(home_team, away_team)
-        return self._compute_probabilities(home_idx, away_idx, max_goals, normalize)
+        return self._compute_probabilities(
+            home_idx, away_idx, max_goals, normalize, bool(neutral_venue)
+        )
 
     def _compute_probabilities_many(
         self,
@@ -395,6 +427,7 @@ class BaseGoalsModel(ABC):
         away_idx: np.ndarray,
         max_goals: int,
         normalize: bool = True,
+        neutral_venue: np.ndarray = None,
     ):
         """
         Optional fast-path for batch probability computation.
@@ -411,6 +444,7 @@ class BaseGoalsModel(ABC):
         away_teams: TeamInput,
         max_goals: int = 15,
         normalize: bool = True,
+        neutral_venue: NeutralVenueInput = None,
     ):
         """
         Predict outcome probabilities for multiple fixtures.
@@ -425,6 +459,10 @@ class BaseGoalsModel(ABC):
             Maximum goals per team to consider.
         normalize : bool, default True
             Whether to normalise each probability grid.
+        neutral_venue : array_like, optional
+            Per-fixture flag (0/1) marking fixtures played at a neutral venue.
+            When 1, home advantage is excluded for that fixture. If None, every
+            fixture is treated as non-neutral.
 
         Returns
         -------
@@ -433,19 +471,25 @@ class BaseGoalsModel(ABC):
             implements `_compute_probabilities_many`, its output is returned.
         """
         home_idx, away_idx = self._predict_many(home_teams, away_teams)
+        neutral = _coerce_neutral_venue(neutral_venue, len(home_idx))
         try:
             return self._compute_probabilities_many(
-                home_idx, away_idx, max_goals, normalize
+                home_idx, away_idx, max_goals, normalize, neutral
             )
         except NotImplementedError:
             return [
-                self._compute_probabilities(h, a, max_goals, normalize)
-                for h, a in zip(home_idx, away_idx)
+                self._compute_probabilities(h, a, max_goals, normalize, bool(nv))
+                for h, a, nv in zip(home_idx, away_idx, neutral)
             ]
 
     @abstractmethod
     def _compute_probabilities(
-        self, home_idx: int, away_idx: int, max_goals: int, normalize: bool = True
+        self,
+        home_idx: int,
+        away_idx: int,
+        max_goals: int,
+        normalize: bool = True,
+        neutral_venue: bool = False,
     ):
         """
         Compute the probability grid for a fixture.

--- a/penaltyblog/models/base_model.py
+++ b/penaltyblog/models/base_model.py
@@ -9,6 +9,7 @@ from scipy.optimize import minimize
 
 from penaltyblog.models.custom_types import (
     GoalInput,
+    NeutralVenueInput,
     TeamInput,
     WeightInput,
 )
@@ -53,6 +54,7 @@ class BaseGoalsModel(ABC):
         teams_home: TeamInput,
         teams_away: TeamInput,
         weights: WeightInput = None,
+        neutral_venue: NeutralVenueInput = None,
     ):
         """
         Initialise the BaseGoalsModel with match data.
@@ -69,11 +71,18 @@ class BaseGoalsModel(ABC):
             Names of away teams for each match.
         weights : WeightInput, optional
             Match weights (e.g., from time decay). If None, all matches are weighted equally.
+        neutral_venue : NeutralVenueInput, optional
+            Per-match flag (0/1) marking matches played at a neutral venue. When 1, the
+            home advantage term is excluded from that match's expected goals during
+            fitting, so the home advantage parameter is estimated only from matches with
+            a genuine home side. If None, all matches are treated as non-neutral and the
+            model behaves exactly as before.
 
         Raises
         ------
         ValueError
-            If the weight array length does not match the number of matches.
+            If the weight or neutral_venue array length does not match the number of
+            matches, or if neutral_venue contains values other than 0 or 1.
         """
         # Use platform-specific integer type for Cython compatibility
         cython_long_dtype = _get_cython_long_dtype()
@@ -92,6 +101,19 @@ class BaseGoalsModel(ABC):
                 raise ValueError(
                     "Weights array must have the same length as the number of matches."
                 )
+
+        if neutral_venue is None:
+            self.neutral_venue = np.zeros(n_matches, dtype=cython_long_dtype, order="C")
+        else:
+            self.neutral_venue = np.asarray(
+                neutral_venue, dtype=cython_long_dtype, order="C"
+            )
+            if len(self.neutral_venue) != n_matches:
+                raise ValueError(
+                    "neutral_venue array must have the same length as the number of matches."
+                )
+            if ((self.neutral_venue != 0) & (self.neutral_venue != 1)).any():
+                raise ValueError("neutral_venue entries must be 0 or 1.")
 
         self._validate_inputs(n_matches)
         self._setup_teams()

--- a/penaltyblog/models/bayesian_goal_model.py
+++ b/penaltyblog/models/bayesian_goal_model.py
@@ -10,7 +10,12 @@ from penaltyblog.bayes.likelihood import (
 )
 from penaltyblog.bayes.sampler_api import EnsembleSampler
 from penaltyblog.models.base_bayesian_model import BaseBayesianModel
-from penaltyblog.models.custom_types import GoalInput, TeamInput, WeightInput
+from penaltyblog.models.custom_types import (
+    GoalInput,
+    NeutralVenueInput,
+    TeamInput,
+    WeightInput,
+)
 from penaltyblog.models.football_probability_grid import (
     FootballProbabilityGrid,
 )
@@ -46,6 +51,7 @@ class BayesianGoalModel(BaseBayesianModel):
         teams_home: TeamInput,
         teams_away: TeamInput,
         weights: WeightInput = None,
+        neutral_venue: NeutralVenueInput = None,
     ):
         """
         Initialize a Bayesian goal model.
@@ -62,8 +68,13 @@ class BayesianGoalModel(BaseBayesianModel):
             Names of away teams for each match.
         weights : WeightInput, optional
             Match weights (e.g., from time decay). If None, all matches are weighted equally.
+        neutral_venue : NeutralVenueInput, optional
+            Per-match flag (0/1) marking matches played at a neutral venue. When 1,
+            home advantage is excluded for that match.
         """
-        super().__init__(goals_home, goals_away, teams_home, teams_away, weights)
+        super().__init__(
+            goals_home, goals_away, teams_home, teams_away, weights, neutral_venue
+        )
 
     def _generate_start_positions(
         self, n_walkers: int, mle_params: Optional[np.ndarray] = None
@@ -145,6 +156,7 @@ class BayesianGoalModel(BaseBayesianModel):
             "goals_home": self.goals_home,
             "goals_away": self.goals_away,
             "weights": self.weights,
+            "neutral_venue": self.neutral_venue,
             "n_teams": self.n_teams,
         }
 
@@ -228,6 +240,7 @@ class BayesianGoalModel(BaseBayesianModel):
             self.teams_home,
             self.teams_away,
             self.weights,
+            neutral_venue=self.neutral_venue,
         )
         simple_model.fit()
 

--- a/penaltyblog/models/bayesian_goal_model.py
+++ b/penaltyblog/models/bayesian_goal_model.py
@@ -189,6 +189,7 @@ class BayesianGoalModel(BaseBayesianModel):
 
         self._params = np.mean(self.trace, axis=0)
         self.fitted = True
+        self._zero_home_advantage_if_all_neutral()
 
     def get_diagnostics(self, burn: int = 0, thin: int = 1) -> pd.DataFrame:
         """
@@ -247,7 +248,12 @@ class BayesianGoalModel(BaseBayesianModel):
         return simple_model._params
 
     def _compute_probabilities(
-        self, home_idx: int, away_idx: int, max_goals: int, normalize: bool = True
+        self,
+        home_idx: int,
+        away_idx: int,
+        max_goals: int,
+        normalize: bool = True,
+        neutral_venue: bool = False,
     ) -> FootballProbabilityGrid:
         """
         Compute posterior predictive probabilities for a fixture.
@@ -258,7 +264,8 @@ class BayesianGoalModel(BaseBayesianModel):
             raise ValueError("Model has not been fitted. Call .fit() first.")
 
         matrix, avg_lam_h, avg_lam_a = bayesian_predict_c(
-            self.trace, home_idx, away_idx, self.n_teams, max_goals
+            self.trace, home_idx, away_idx, self.n_teams, max_goals,
+            int(neutral_venue),
         )
         return FootballProbabilityGrid(
             matrix, avg_lam_h, avg_lam_a, normalize=normalize

--- a/penaltyblog/models/bivariate_poisson.py
+++ b/penaltyblog/models/bivariate_poisson.py
@@ -6,6 +6,7 @@ from numpy.typing import NDArray
 from penaltyblog.models.base_model import BaseGoalsModel
 from penaltyblog.models.custom_types import (
     GoalInput,
+    NeutralVenueInput,
     ParamsOutput,
     TeamInput,
     WeightInput,
@@ -34,6 +35,7 @@ class BivariatePoissonGoalModel(BaseGoalsModel):
         teams_home: TeamInput,
         teams_away: TeamInput,
         weights: WeightInput = None,
+        neutral_venue: NeutralVenueInput = None,
     ):
         """
         Initialises the BivariatePoissonGoalModel class.
@@ -50,8 +52,13 @@ class BivariatePoissonGoalModel(BaseGoalsModel):
             The names of the away teams
         weights : array_like, optional
             The weights of the matches, by default None
+        neutral_venue : array_like, optional
+            Per-match flag (0/1) marking matches played at a neutral venue. When 1,
+            home advantage is excluded for that match, by default None
         """
-        super().__init__(goals_home, goals_away, teams_home, teams_away, weights)
+        super().__init__(
+            goals_home, goals_away, teams_home, teams_away, weights, neutral_venue
+        )
 
         self._params = np.concatenate(
             (
@@ -118,6 +125,7 @@ class BivariatePoissonGoalModel(BaseGoalsModel):
             self.weights,
             self.home_idx,
             self.away_idx,
+            self.neutral_venue,
             attack,
             defence,
             hfa,
@@ -145,6 +153,7 @@ class BivariatePoissonGoalModel(BaseGoalsModel):
             self.goals_home,
             self.goals_away,
             self.weights,
+            self.neutral_venue,
         )
 
     def fit(self, minimizer_options: Optional[dict] = None, use_gradient: bool = True):

--- a/penaltyblog/models/bivariate_poisson.py
+++ b/penaltyblog/models/bivariate_poisson.py
@@ -184,13 +184,18 @@ class BivariatePoissonGoalModel(BaseGoalsModel):
         )
 
     def _compute_probabilities(
-        self, home_idx: int, away_idx: int, max_goals: int, normalize: bool = True
+        self,
+        home_idx: int,
+        away_idx: int,
+        max_goals: int,
+        normalize: bool = True,
+        neutral_venue: bool = False,
     ) -> FootballProbabilityGrid:
         home_attack = self._params[home_idx]
         away_attack = self._params[away_idx]
         home_defense = self._params[home_idx + self.n_teams]
         away_defense = self._params[away_idx + self.n_teams]
-        home_advantage = self._params[-2]
+        home_advantage = 0.0 if neutral_venue else self._params[-2]
         correlation = self._params[-1]
 
         # Preallocate the score matrix as a flattened array.
@@ -228,6 +233,7 @@ class BivariatePoissonGoalModel(BaseGoalsModel):
         away_idx: np.ndarray,
         max_goals: int,
         normalize: bool = True,
+        neutral_venue: np.ndarray = None,
     ):
         """
         Batch probability computation for multiple fixtures.
@@ -246,7 +252,6 @@ class BivariatePoissonGoalModel(BaseGoalsModel):
         lambda_away = np.empty(1, dtype=np.float64)
 
         correlation = self._params[-1]
-        home_advantage = self._params[-2]
 
         for i in range(n):
             h_idx = int(home_idx[i])
@@ -256,6 +261,11 @@ class BivariatePoissonGoalModel(BaseGoalsModel):
             away_attack = self._params[a_idx]
             home_defense = self._params[h_idx + self.n_teams]
             away_defense = self._params[a_idx + self.n_teams]
+            home_advantage = (
+                0.0
+                if neutral_venue is not None and neutral_venue[i]
+                else self._params[-2]
+            )
 
             compute_bivariate_poisson_probabilities(
                 float(home_attack),

--- a/penaltyblog/models/custom_types.py
+++ b/penaltyblog/models/custom_types.py
@@ -7,4 +7,12 @@ from numpy.typing import NDArray
 GoalInput = Union[Sequence[int], NDArray[np.int64], pd.Series]
 TeamInput = Union[Sequence[str], NDArray[np.str_], pd.Series]
 WeightInput = Union[float, Sequence[float], NDArray[np.float64], pd.Series, None]
+NeutralVenueInput = Union[
+    Sequence[int],
+    Sequence[bool],
+    NDArray[np.int64],
+    NDArray[np.bool_],
+    pd.Series,
+    None,
+]
 ParamsOutput = Dict[str, float]

--- a/penaltyblog/models/dixon_coles.py
+++ b/penaltyblog/models/dixon_coles.py
@@ -6,6 +6,7 @@ from numpy.typing import NDArray
 from penaltyblog.models.base_model import BaseGoalsModel
 from penaltyblog.models.custom_types import (
     GoalInput,
+    NeutralVenueInput,
     TeamInput,
     WeightInput,
 )
@@ -43,6 +44,7 @@ class DixonColesGoalModel(BaseGoalsModel):
         teams_home: TeamInput,
         teams_away: TeamInput,
         weights: WeightInput = None,
+        neutral_venue: NeutralVenueInput = None,
     ):
         """
         Dixon and Coles adjusted Poisson model for predicting outcomes of football
@@ -60,8 +62,13 @@ class DixonColesGoalModel(BaseGoalsModel):
             The name of the away team in each match
         weights : array_like, optional
             The weight of each match, by default None
+        neutral_venue : array_like, optional
+            Per-match flag (0/1) marking matches played at a neutral venue. When 1,
+            home advantage is excluded for that match, by default None
         """
-        super().__init__(goals_home, goals_away, teams_home, teams_away, weights)
+        super().__init__(
+            goals_home, goals_away, teams_home, teams_away, weights, neutral_venue
+        )
 
         self._params = np.concatenate(
             (
@@ -143,6 +150,7 @@ class DixonColesGoalModel(BaseGoalsModel):
             self.goals_home,
             self.goals_away,
             self.weights,
+            self.neutral_venue,
         )
 
     def _loss_function(self, params: NDArray) -> float:
@@ -163,6 +171,7 @@ class DixonColesGoalModel(BaseGoalsModel):
             self.weights,
             self.home_idx,
             self.away_idx,
+            self.neutral_venue,
             attack,
             defence,
             hfa,

--- a/penaltyblog/models/dixon_coles.py
+++ b/penaltyblog/models/dixon_coles.py
@@ -220,13 +220,18 @@ class DixonColesGoalModel(BaseGoalsModel):
         )
 
     def _compute_probabilities(
-        self, home_idx: int, away_idx: int, max_goals: int, normalize: bool = True
+        self,
+        home_idx: int,
+        away_idx: int,
+        max_goals: int,
+        normalize: bool = True,
+        neutral_venue: bool = False,
     ) -> FootballProbabilityGrid:
         home_attack = self._params[home_idx]
         away_attack = self._params[away_idx]
         home_defense = self._params[home_idx + self.n_teams]
         away_defense = self._params[away_idx + self.n_teams]
-        home_advantage = self._params[-2]
+        home_advantage = 0.0 if neutral_venue else self._params[-2]
         rho = self._params[-1]
 
         # Preallocate the score matrix as a flattened array.
@@ -264,6 +269,7 @@ class DixonColesGoalModel(BaseGoalsModel):
         away_idx: np.ndarray,
         max_goals: int,
         normalize: bool = True,
+        neutral_venue: np.ndarray = None,
     ):
         """
         Batch probability computation for multiple fixtures.
@@ -282,7 +288,6 @@ class DixonColesGoalModel(BaseGoalsModel):
         lambda_away = np.empty(1, dtype=np.float64)
 
         rho = self._params[-1]
-        home_advantage = self._params[-2]
 
         for i in range(n):
             h_idx = int(home_idx[i])
@@ -292,6 +297,11 @@ class DixonColesGoalModel(BaseGoalsModel):
             away_attack = self._params[a_idx]
             home_defense = self._params[h_idx + self.n_teams]
             away_defense = self._params[a_idx + self.n_teams]
+            home_advantage = (
+                0.0
+                if neutral_venue is not None and neutral_venue[i]
+                else self._params[-2]
+            )
 
             compute_dixon_coles_probabilities(
                 float(home_attack),

--- a/penaltyblog/models/gradients.pyx
+++ b/penaltyblog/models/gradients.pyx
@@ -45,7 +45,8 @@ def poisson_gradient(
     cnp.ndarray[long, ndim=1] away_idx,
     cnp.ndarray[long, ndim=1] goals_home,
     cnp.ndarray[long, ndim=1] goals_away,
-    cnp.ndarray[double, ndim=1] weights
+    cnp.ndarray[double, ndim=1] weights,
+    cnp.ndarray[long, ndim=1] neutral_venue
 ):
     cdef int n_teams = attack.shape[0]
     cdef int n_games = home_idx.shape[0]
@@ -55,7 +56,7 @@ def poisson_gradient(
     cdef cnp.ndarray[double, ndim=1] grad_defence = np.zeros(n_teams, dtype=np.float64)
     cdef double grad_hfa = 0.0
 
-    cdef int i
+    cdef int i, home_flag
     cdef long h, a
     cdef double lambda_home, lambda_away
 
@@ -63,14 +64,16 @@ def poisson_gradient(
         h = home_idx[i]
         a = away_idx[i]
 
-        lambda_home = exp(attack[h] + defence[a] + hfa)
+        # home_flag is 0 for neutral-venue matches, so home advantage drops out.
+        home_flag = 1 - neutral_venue[i]
+        lambda_home = exp(attack[h] + defence[a] + hfa * home_flag)
         lambda_away = exp(attack[a] + defence[h])
 
         grad_attack[h] += (goals_home[i] - lambda_home) * weights[i]
         grad_attack[a] += (goals_away[i] - lambda_away) * weights[i]
         grad_defence[a] += (goals_home[i] - lambda_home) * weights[i]
         grad_defence[h] += (goals_away[i] - lambda_away) * weights[i]
-        grad_hfa += (goals_home[i] - lambda_home) * weights[i]
+        grad_hfa += (goals_home[i] - lambda_home) * home_flag * weights[i]
 
     return np.concatenate([grad_attack, grad_defence, [grad_hfa]])
 
@@ -89,7 +92,8 @@ def dixon_coles_gradient(
     cnp.ndarray[long, ndim=1] away_idx,
     cnp.ndarray[long, ndim=1] goals_home,
     cnp.ndarray[long, ndim=1] goals_away,
-    cnp.ndarray[double, ndim=1] weights
+    cnp.ndarray[double, ndim=1] weights,
+    cnp.ndarray[long, ndim=1] neutral_venue
 ):
     cdef int n_teams = attack.shape[0]
     cdef int n_games = home_idx.shape[0]
@@ -100,7 +104,7 @@ def dixon_coles_gradient(
     cdef double grad_hfa = 0.0
     cdef double grad_rho = 0.0
 
-    cdef int i, h, a
+    cdef int i, h, a, home_flag
     cdef double lambda_home, lambda_away, adj_factor
     cdef int k_home, k_away
 
@@ -108,7 +112,9 @@ def dixon_coles_gradient(
         h = home_idx[i]
         a = away_idx[i]
 
-        lambda_home = exp(hfa + attack[h] + defence[a])
+        # home_flag is 0 for neutral-venue matches, so home advantage drops out.
+        home_flag = 1 - neutral_venue[i]
+        lambda_home = exp(hfa * home_flag + attack[h] + defence[a])
         lambda_away = exp(attack[a] + defence[h])
 
         k_home = goals_home[i]
@@ -119,7 +125,7 @@ def dixon_coles_gradient(
         grad_attack[a] += (k_away - lambda_away) * weights[i]
         grad_defence[a] += (k_home - lambda_home) * weights[i]
         grad_defence[h] += (k_away - lambda_away) * weights[i]
-        grad_hfa += (k_home - lambda_home) * weights[i]
+        grad_hfa += (k_home - lambda_home) * home_flag * weights[i]
 
         # Compute rho gradient only for low-score matches
         adj_factor = 0.0
@@ -159,7 +165,8 @@ def zero_inflated_poisson_gradient(
     cnp.ndarray[long, ndim=1] away_idx,
     cnp.ndarray[long, ndim=1] goals_home,
     cnp.ndarray[long, ndim=1] goals_away,
-    cnp.ndarray[double, ndim=1] weights
+    cnp.ndarray[double, ndim=1] weights,
+    cnp.ndarray[long, ndim=1] neutral_venue
 ):
     cdef int n_teams = attack.shape[0]
     cdef int n_games = home_idx.shape[0]
@@ -170,7 +177,7 @@ def zero_inflated_poisson_gradient(
     cdef double grad_hfa = 0.0
     cdef double grad_phi = 0.0
 
-    cdef int i, h, a
+    cdef int i, h, a, home_flag
     cdef long k_home, k_away
     cdef double w
     cdef double lambda_home, lambda_away
@@ -191,7 +198,9 @@ def zero_inflated_poisson_gradient(
         k_away = goals_away[i]
         w = weights[i]
 
-        lambda_home = exp(attack[h] + defence[a] + hfa)
+        # home_flag is 0 for neutral-venue matches, so home advantage drops out.
+        home_flag = 1 - neutral_venue[i]
+        lambda_home = exp(attack[h] + defence[a] + hfa * home_flag)
         lambda_away = exp(attack[a] + defence[h])
 
         # Home goal contribution to gradient
@@ -205,7 +214,7 @@ def zero_inflated_poisson_gradient(
 
         grad_attack[h] += grad_lambda_h_contrib * w
         grad_defence[a] += grad_lambda_h_contrib * w
-        grad_hfa += grad_lambda_h_contrib * w
+        grad_hfa += grad_lambda_h_contrib * home_flag * w
 
         # Away goal contribution to gradient
         if k_away == 0:
@@ -236,7 +245,8 @@ def negative_binomial_gradient(
     cnp.ndarray[long, ndim=1] away_idx,
     cnp.ndarray[long, ndim=1] goals_home,
     cnp.ndarray[long, ndim=1] goals_away,
-    cnp.ndarray[double, ndim=1] weights
+    cnp.ndarray[double, ndim=1] weights,
+    cnp.ndarray[long, ndim=1] neutral_venue
 ):
     cdef int n_teams = attack.shape[0]
     cdef int n_games = home_idx.shape[0]
@@ -247,7 +257,7 @@ def negative_binomial_gradient(
     cdef double grad_hfa = 0.0
     cdef double grad_dispersion = 0.0
 
-    cdef int i, h, a, k_home, k_away
+    cdef int i, h, a, k_home, k_away, home_flag
     cdef double lambda_home, lambda_away
     cdef double grad_home, grad_away
     cdef double term_disp_home, term_disp_away
@@ -263,7 +273,9 @@ def negative_binomial_gradient(
         k_away = goals_away[i]
 
         # Compute expected goals for home and away.
-        lambda_home = exp(hfa + attack[h] + defence[a])
+        # home_flag is 0 for neutral-venue matches, so home advantage drops out.
+        home_flag = 1 - neutral_venue[i]
+        lambda_home = exp(hfa * home_flag + attack[h] + defence[a])
         lambda_away = exp(attack[a] + defence[h])
 
         # For parameters that affect lambda, the derivative (for one observation) is:
@@ -274,7 +286,7 @@ def negative_binomial_gradient(
         # Accumulate gradients for home match:
         grad_attack[h] += grad_home
         grad_defence[a] += grad_home
-        grad_hfa += grad_home
+        grad_hfa += grad_home * home_flag
         # For away match:
         grad_attack[a] += grad_away
         grad_defence[h] += grad_away
@@ -305,7 +317,8 @@ def bivariate_poisson_gradient(
     cnp.ndarray[long, ndim=1] away_idx,
     cnp.ndarray[long, ndim=1] goals_home,
     cnp.ndarray[long, ndim=1] goals_away,
-    cnp.ndarray[double, ndim=1] weights
+    cnp.ndarray[double, ndim=1] weights,
+    cnp.ndarray[long, ndim=1] neutral_venue
 ):
     """
     Compute the gradient of the negative log-likelihood for the Bivariate Poisson model.
@@ -328,7 +341,7 @@ def bivariate_poisson_gradient(
     cdef double grad_hfa = 0.0
     cdef double grad_correlation = 0.0
 
-    cdef int i, h, a, k_home, k_away, k, kmax
+    cdef int i, h, a, k_home, k_away, k, kmax, home_flag
     cdef double lambda1, lambda2, w
     cdef double likelihood_ij, grad_lambda1, grad_lambda2, grad_lambda3
     cdef double term_k, pmf1_k, pmf2_k, pmf3_k
@@ -350,7 +363,9 @@ def bivariate_poisson_gradient(
         w = weights[i]
 
         # Compute lambdas for this match
-        lambda1 = exp(hfa + attack[h] + defence[a])
+        # home_flag is 0 for neutral-venue matches, so home advantage drops out.
+        home_flag = 1 - neutral_venue[i]
+        lambda1 = exp(hfa * home_flag + attack[h] + defence[a])
         lambda2 = exp(attack[a] + defence[h])
 
         # Compute the likelihood for this observation
@@ -405,7 +420,7 @@ def bivariate_poisson_gradient(
         grad_attack[a] += grad_lambda2 * lambda2
         grad_defence[a] += grad_lambda1 * lambda1
         grad_defence[h] += grad_lambda2 * lambda2
-        grad_hfa += grad_lambda1 * lambda1
+        grad_hfa += grad_lambda1 * lambda1 * home_flag
         grad_correlation += grad_lambda3 * lambda3
 
     return np.concatenate([grad_attack, grad_defence, [grad_hfa, grad_correlation]])
@@ -427,6 +442,7 @@ def weibull_copula_gradient(
     cnp.ndarray[long, ndim=1] goals_home,
     cnp.ndarray[long, ndim=1] goals_away,
     cnp.ndarray[double, ndim=1] weights,
+    cnp.ndarray[long, ndim=1] neutral_venue,
     int max_goals
 ):
     """
@@ -446,7 +462,7 @@ def weibull_copula_gradient(
     cdef double grad_shape = 0.0
     cdef double grad_kappa = 0.0
 
-    cdef int i, h, a, x_i, y_i
+    cdef int i, h, a, x_i, y_i, home_flag
     cdef double lambda_home, lambda_away, w
     cdef double p_xy, grad_factor
     cdef double grad_p_xy_lambda_h, grad_p_xy_lambda_a, grad_p_xy_shape, grad_p_xy_kappa
@@ -479,7 +495,9 @@ def weibull_copula_gradient(
         w = weights[i]
 
         # Compute expected goals
-        lambda_home = exp(hfa + attack[h] + defence[a])
+        # home_flag is 0 for neutral-venue matches, so home advantage drops out.
+        home_flag = 1 - neutral_venue[i]
+        lambda_home = exp(hfa * home_flag + attack[h] + defence[a])
         lambda_away = exp(attack[a] + defence[h])
 
         # Compute Weibull PMFs and CDFs at current params
@@ -536,7 +554,7 @@ def weibull_copula_gradient(
         grad_attack[a] += grad_factor * grad_p_xy_lambda_a * lambda_away
         grad_defence[a] += grad_factor * grad_p_xy_lambda_h * lambda_home
         grad_defence[h] += grad_factor * grad_p_xy_lambda_a * lambda_away
-        grad_hfa += grad_factor * grad_p_xy_lambda_h * lambda_home
+        grad_hfa += grad_factor * grad_p_xy_lambda_h * lambda_home * home_flag
 
         # Direct gradients for shape and kappa
         grad_shape += grad_factor * grad_p_xy_shape

--- a/penaltyblog/models/hierarchical_bayesian_goal_model.py
+++ b/penaltyblog/models/hierarchical_bayesian_goal_model.py
@@ -89,6 +89,7 @@ class HierarchicalBayesianGoalModel(BayesianGoalModel):
 
         self._params = np.mean(self.trace, axis=0)
         self.fitted = True
+        self._zero_home_advantage_if_all_neutral()
 
     def _generate_hierarchical_starts(
         self, n_walkers: int, mle_params: np.ndarray

--- a/penaltyblog/models/hierarchical_bayesian_goal_model.py
+++ b/penaltyblog/models/hierarchical_bayesian_goal_model.py
@@ -61,6 +61,7 @@ class HierarchicalBayesianGoalModel(BayesianGoalModel):
             "goals_home": self.goals_home,
             "goals_away": self.goals_away,
             "weights": self.weights,
+            "neutral_venue": self.neutral_venue,
             "n_teams": self.n_teams,
         }
 

--- a/penaltyblog/models/loss.pyx
+++ b/penaltyblog/models/loss.pyx
@@ -33,6 +33,7 @@ cpdef double poisson_loss_function(long[:] goals_home,
                                    np.float64_t[:] weights,
                                    long[:] home_indices,
                                    long[:] away_indices,
+                                   long[:] neutral_venue,
                                    np.float64_t[:] attack,
                                    np.float64_t[:] defence,
                                    double hfa):
@@ -43,6 +44,7 @@ cpdef double poisson_loss_function(long[:] goals_home,
       goals_home, goals_away: observed goals for home and away teams.
       weights: match weights.
       home_indices, away_indices: indices mapping each fixture to team parameters.
+      neutral_venue: per-match flag (0/1); when 1, home advantage is excluded for that match.
       attack, defence: team parameters.
       hfa: home advantage.
 
@@ -60,8 +62,8 @@ cpdef double poisson_loss_function(long[:] goals_home,
             home_idx = home_indices[i]
             away_idx = away_indices[i]
 
-            # Compute expected goals
-            lambda_home = exp(hfa + attack[home_idx] + defence[away_idx])
+            # Compute expected goals (home advantage excluded for neutral venues)
+            lambda_home = exp(hfa * (1 - neutral_venue[i]) + attack[home_idx] + defence[away_idx])
             lambda_away = exp(attack[away_idx] + defence[home_idx])
 
             # Retrieve observed goals
@@ -87,6 +89,7 @@ cpdef double dixon_coles_loss_function(long[:] goals_home,
                                          np.float64_t[:] weights,
                                          long[:] home_indices,
                                          long[:] away_indices,
+                                         long[:] neutral_venue,
                                          np.float64_t[:] attack,
                                          np.float64_t[:] defence,
                                          double hfa,
@@ -98,6 +101,7 @@ cpdef double dixon_coles_loss_function(long[:] goals_home,
       goals_home, goals_away: observed goals for home and away teams.
       weights: match weights.
       home_indices, away_indices: indices mapping each fixture to team parameters.
+      neutral_venue: per-match flag (0/1); when 1, home advantage is excluded for that match.
       attack, defence: team parameters.
       hfa: home advantage.
       rho: Dixon–Coles adjustment parameter.
@@ -115,7 +119,8 @@ cpdef double dixon_coles_loss_function(long[:] goals_home,
         away_idx = away_indices[i]
 
         # Compute expected goals using team parameters and home advantage.
-        lambda_home = exp(hfa + attack[home_idx] + defence[away_idx])
+        # Home advantage is excluded for matches played at a neutral venue.
+        lambda_home = exp(hfa * (1 - neutral_venue[i]) + attack[home_idx] + defence[away_idx])
         lambda_away = exp(attack[away_idx] + defence[home_idx])
 
         k_home = goals_home[i]
@@ -152,6 +157,7 @@ cpdef double compute_negative_binomial_loss(long[:] goals_home,
                                          np.float64_t[:] weights,
                                          long[:] home_indices,
                                          long[:] away_indices,
+                                         long[:] neutral_venue,
                                          np.float64_t[:] attack,
                                          np.float64_t[:] defence,
                                          double hfa,
@@ -189,7 +195,8 @@ cpdef double compute_negative_binomial_loss(long[:] goals_home,
         home_idx = home_indices[i]
         away_idx = away_indices[i]
         # Attack parameters: first nTeams elements; Defence: next nTeams elements
-        lambdaHome = exp(hfa + attack[home_idx] + defence[away_idx])
+        # Home advantage is excluded for matches played at a neutral venue.
+        lambdaHome = exp(hfa * (1 - neutral_venue[i]) + attack[home_idx] + defence[away_idx])
         lambdaAway = exp(attack[away_idx] + defence[home_idx])
         pHome = dispersion / (dispersion + lambdaHome)
         pAway = dispersion / (dispersion + lambdaAway)
@@ -215,6 +222,7 @@ cpdef double compute_zero_inflated_poisson_loss(long[:] goals_home,
                                          np.float64_t[:] weights,
                                          long[:] home_indices,
                                          long[:] away_indices,
+                                         long[:] neutral_venue,
                                          np.float64_t[:] attack,
                                          np.float64_t[:] defence,
                                          double hfa,
@@ -246,7 +254,8 @@ cpdef double compute_zero_inflated_poisson_loss(long[:] goals_home,
         home_idx = home_indices[i]
         away_idx = away_indices[i]
 
-        lambda_home = exp(hfa + attack[home_idx] + defence[away_idx])
+        # Home advantage is excluded for matches played at a neutral venue.
+        lambda_home = exp(hfa * (1 - neutral_venue[i]) + attack[home_idx] + defence[away_idx])
         lambda_away = exp(attack[away_idx] + defence[home_idx])
 
         k_home = goals_home[i]
@@ -277,6 +286,7 @@ cpdef double compute_bivariate_poisson_loss(long[:] goals_home,
                                          np.float64_t[:] weights,
                                          long[:] home_indices,
                                          long[:] away_indices,
+                                         long[:] neutral_venue,
                                          np.float64_t[:] attack,
                                          np.float64_t[:] defence,
                                          double hfa,
@@ -321,7 +331,8 @@ cpdef double compute_bivariate_poisson_loss(long[:] goals_home,
         away_idx = away_indices[i]
 
         # Compute lambda1 and lambda2 for the match.
-        lambda1 = exp(hfa + attack[home_idx] + defence[away_idx])
+        # Home advantage is excluded for matches played at a neutral venue.
+        lambda1 = exp(hfa * (1 - neutral_venue[i]) + attack[home_idx] + defence[away_idx])
         lambda2 = exp(attack[away_idx] + defence[home_idx])
 
         # Get or compute the PMF for lambda1.
@@ -364,6 +375,7 @@ cpdef double compute_weibull_copula_loss(long[:] goals_home,
                                          np.float64_t[:] weights,
                                          long[:] home_indices,
                                          long[:] away_indices,
+                                         long[:] neutral_venue,
                                          np.float64_t[:] attack,
                                          np.float64_t[:] defence,
                                          double hfa,
@@ -408,7 +420,8 @@ cpdef double compute_weibull_copula_loss(long[:] goals_home,
         home_index = home_indices[i]
         away_index = away_indices[i]
 
-        lambdaHome = exp(hfa + attack[home_index] + defence[away_index])
+        # Home advantage is excluded for matches played at a neutral venue.
+        lambdaHome = exp(hfa * (1 - neutral_venue[i]) + attack[home_index] + defence[away_index])
         lambdaAway = exp(attack[away_index] + defence[home_index])
 
         # Compute the Weibull PMFs.

--- a/penaltyblog/models/negative_binomial.py
+++ b/penaltyblog/models/negative_binomial.py
@@ -5,6 +5,7 @@ import numpy as np
 from penaltyblog.models.base_model import BaseGoalsModel
 from penaltyblog.models.custom_types import (
     GoalInput,
+    NeutralVenueInput,
     TeamInput,
     WeightInput,
 )
@@ -42,6 +43,7 @@ class NegativeBinomialGoalModel(BaseGoalsModel):
         teams_home: TeamInput,
         teams_away: TeamInput,
         weights: WeightInput = None,
+        neutral_venue: NeutralVenueInput = None,
     ):
         """
         Initialises the NegativeBinomialGoalModel class.
@@ -58,8 +60,13 @@ class NegativeBinomialGoalModel(BaseGoalsModel):
             The names of the away teams
         weights : array_like, optional
             The weights of the matches, by default None
+        neutral_venue : array_like, optional
+            Per-match flag (0/1) marking matches played at a neutral venue. When 1,
+            home advantage is excluded for that match, by default None
         """
-        super().__init__(goals_home, goals_away, teams_home, teams_away, weights)
+        super().__init__(
+            goals_home, goals_away, teams_home, teams_away, weights, neutral_venue
+        )
 
         self._params = np.concatenate(
             ([1] * self.n_teams, [-1] * self.n_teams, [0.25], [0.1])
@@ -132,6 +139,7 @@ class NegativeBinomialGoalModel(BaseGoalsModel):
             self.goals_home,
             self.goals_away,
             self.weights,
+            self.neutral_venue,
         )
 
         # Remove excessive clipping that can interfere with optimization
@@ -168,6 +176,7 @@ class NegativeBinomialGoalModel(BaseGoalsModel):
             self.weights,
             self.home_idx,
             self.away_idx,
+            self.neutral_venue,
             attack,
             defence,
             hfa,

--- a/penaltyblog/models/negative_binomial.py
+++ b/penaltyblog/models/negative_binomial.py
@@ -218,13 +218,18 @@ class NegativeBinomialGoalModel(BaseGoalsModel):
         )
 
     def _compute_probabilities(
-        self, home_idx: int, away_idx: int, max_goals: int, normalize: bool = True
+        self,
+        home_idx: int,
+        away_idx: int,
+        max_goals: int,
+        normalize: bool = True,
+        neutral_venue: bool = False,
     ) -> FootballProbabilityGrid:
         home_attack = self._params[home_idx]
         away_attack = self._params[away_idx]
         home_defense = self._params[home_idx + self.n_teams]
         away_defense = self._params[away_idx + self.n_teams]
-        home_advantage = self._params[-2]
+        home_advantage = 0.0 if neutral_venue else self._params[-2]
         dispersion = self._params[-1]
 
         # Preallocate the score matrix as a flattened array.
@@ -262,6 +267,7 @@ class NegativeBinomialGoalModel(BaseGoalsModel):
         away_idx: np.ndarray,
         max_goals: int,
         normalize: bool = True,
+        neutral_venue: np.ndarray = None,
     ):
         """
         Batch probability computation for multiple fixtures.
@@ -279,7 +285,6 @@ class NegativeBinomialGoalModel(BaseGoalsModel):
         lambda_home = np.empty(1, dtype=np.float64)
         lambda_away = np.empty(1, dtype=np.float64)
 
-        home_advantage = self._params[-2]
         dispersion = self._params[-1]
 
         for i in range(n):
@@ -290,6 +295,11 @@ class NegativeBinomialGoalModel(BaseGoalsModel):
             away_attack = self._params[a_idx]
             home_defense = self._params[h_idx + self.n_teams]
             away_defense = self._params[a_idx + self.n_teams]
+            home_advantage = (
+                0.0
+                if neutral_venue is not None and neutral_venue[i]
+                else self._params[-2]
+            )
 
             compute_negative_binomial_probabilities(
                 float(home_attack),

--- a/penaltyblog/models/poisson.py
+++ b/penaltyblog/models/poisson.py
@@ -5,6 +5,7 @@ import numpy as np
 from penaltyblog.models.base_model import BaseGoalsModel
 from penaltyblog.models.custom_types import (
     GoalInput,
+    NeutralVenueInput,
     TeamInput,
     WeightInput,
 )
@@ -41,6 +42,7 @@ class PoissonGoalsModel(BaseGoalsModel):
         teams_home: TeamInput,
         teams_away: TeamInput,
         weights: WeightInput = None,
+        neutral_venue: NeutralVenueInput = None,
     ):
         """
         Dixon and Coles adjusted Poisson model for predicting outcomes of football
@@ -58,8 +60,13 @@ class PoissonGoalsModel(BaseGoalsModel):
             The name of the away team in each match
         weights : array_like, optional
             The weight of each match, by default None
+        neutral_venue : array_like, optional
+            Per-match flag (0/1) marking matches played at a neutral venue. When 1,
+            home advantage is excluded for that match, by default None
         """
-        super().__init__(goals_home, goals_away, teams_home, teams_away, weights)
+        super().__init__(
+            goals_home, goals_away, teams_home, teams_away, weights, neutral_venue
+        )
 
         self._params = np.concatenate(
             (
@@ -135,6 +142,7 @@ class PoissonGoalsModel(BaseGoalsModel):
             self.goals_home,
             self.goals_away,
             self.weights,
+            self.neutral_venue,
         )
 
     def _loss_function(self, params):
@@ -155,6 +163,7 @@ class PoissonGoalsModel(BaseGoalsModel):
             self.weights,
             self.home_idx,
             self.away_idx,
+            self.neutral_venue,
             attack,
             defence,
             hfa,

--- a/penaltyblog/models/poisson.py
+++ b/penaltyblog/models/poisson.py
@@ -205,13 +205,18 @@ class PoissonGoalsModel(BaseGoalsModel):
         )
 
     def _compute_probabilities(
-        self, home_idx: int, away_idx: int, max_goals: int, normalize: bool = True
+        self,
+        home_idx: int,
+        away_idx: int,
+        max_goals: int,
+        normalize: bool = True,
+        neutral_venue: bool = False,
     ) -> FootballProbabilityGrid:
         home_attack = self._params[home_idx]
         away_attack = self._params[away_idx]
         home_defense = self._params[home_idx + self.n_teams]
         away_defense = self._params[away_idx + self.n_teams]
-        home_advantage = self._params[-1]
+        home_advantage = 0.0 if neutral_venue else self._params[-1]
 
         # Preallocate the score matrix as a flattened array.
         score_matrix = np.empty(max_goals * max_goals, dtype=np.float64)
@@ -247,6 +252,7 @@ class PoissonGoalsModel(BaseGoalsModel):
         away_idx: np.ndarray,
         max_goals: int,
         normalize: bool = True,
+        neutral_venue: np.ndarray = None,
     ):
         """
         Batch probability computation for multiple fixtures.
@@ -272,7 +278,11 @@ class PoissonGoalsModel(BaseGoalsModel):
             away_attack = self._params[a_idx]
             home_defense = self._params[h_idx + self.n_teams]
             away_defense = self._params[a_idx + self.n_teams]
-            home_advantage = self._params[-1]
+            home_advantage = (
+                0.0
+                if neutral_venue is not None and neutral_venue[i]
+                else self._params[-1]
+            )
 
             compute_poisson_probabilities(
                 float(home_attack),

--- a/penaltyblog/models/weibull_copula.py
+++ b/penaltyblog/models/weibull_copula.py
@@ -4,7 +4,12 @@ import numpy as np
 from numpy.typing import NDArray
 
 from penaltyblog.models.base_model import BaseGoalsModel
-from penaltyblog.models.custom_types import GoalInput, TeamInput, WeightInput
+from penaltyblog.models.custom_types import (
+    GoalInput,
+    NeutralVenueInput,
+    TeamInput,
+    WeightInput,
+)
 from penaltyblog.models.football_probability_grid import (
     FootballProbabilityGrid,
 )
@@ -38,6 +43,7 @@ class WeibullCopulaGoalsModel(BaseGoalsModel):
         teams_home: TeamInput,
         teams_away: TeamInput,
         weights: WeightInput = None,
+        neutral_venue: NeutralVenueInput = None,
     ):
         """
         Initialises the WeibullCopulaGoalModel class.
@@ -54,8 +60,13 @@ class WeibullCopulaGoalsModel(BaseGoalsModel):
             The names of the away teams
         weights : array_like, optional
             The weights of the matches, by default None
+        neutral_venue : array_like, optional
+            Per-match flag (0/1) marking matches played at a neutral venue. When 1,
+            home advantage is excluded for that match, by default None
         """
-        super().__init__(goals_home, goals_away, teams_home, teams_away, weights)
+        super().__init__(
+            goals_home, goals_away, teams_home, teams_away, weights, neutral_venue
+        )
 
         # Quick guess initialization
         rng = np.random.default_rng()
@@ -144,6 +155,7 @@ class WeibullCopulaGoalsModel(BaseGoalsModel):
             self.weights,
             self.home_idx,
             self.away_idx,
+            self.neutral_venue,
             attack,
             defence,
             hfa,
@@ -174,6 +186,7 @@ class WeibullCopulaGoalsModel(BaseGoalsModel):
             self.goals_home,
             self.goals_away,
             self.weights,
+            self.neutral_venue,
             self.max_goals,
         )
 

--- a/penaltyblog/models/weibull_copula.py
+++ b/penaltyblog/models/weibull_copula.py
@@ -233,13 +233,18 @@ class WeibullCopulaGoalsModel(BaseGoalsModel):
         )
 
     def _compute_probabilities(
-        self, home_idx: int, away_idx: int, max_goals: int, normalize: bool = True
+        self,
+        home_idx: int,
+        away_idx: int,
+        max_goals: int,
+        normalize: bool = True,
+        neutral_venue: bool = False,
     ) -> FootballProbabilityGrid:
         home_attack = self._params[home_idx]
         away_attack = self._params[away_idx]
         home_defense = self._params[home_idx + self.n_teams]
         away_defense = self._params[away_idx + self.n_teams]
-        home_advantage = self._params[-3]
+        home_advantage = 0.0 if neutral_venue else self._params[-3]
         shape = self._params[-2]
         kappa = self._params[-1]
 
@@ -279,6 +284,7 @@ class WeibullCopulaGoalsModel(BaseGoalsModel):
         away_idx: np.ndarray,
         max_goals: int,
         normalize: bool = True,
+        neutral_venue: np.ndarray = None,
     ):
         """
         Batch probability computation for multiple fixtures.
@@ -296,7 +302,6 @@ class WeibullCopulaGoalsModel(BaseGoalsModel):
         lambda_home = np.empty(1, dtype=np.float64)
         lambda_away = np.empty(1, dtype=np.float64)
 
-        home_advantage = self._params[-3]
         shape = self._params[-2]
         kappa = self._params[-1]
 
@@ -308,6 +313,11 @@ class WeibullCopulaGoalsModel(BaseGoalsModel):
             away_attack = self._params[a_idx]
             home_defense = self._params[h_idx + self.n_teams]
             away_defense = self._params[a_idx + self.n_teams]
+            home_advantage = (
+                0.0
+                if neutral_venue is not None and neutral_venue[i]
+                else self._params[-3]
+            )
 
             compute_weibull_copula_probabilities(
                 float(home_attack),

--- a/penaltyblog/models/zero_inf_poisson.py
+++ b/penaltyblog/models/zero_inf_poisson.py
@@ -11,6 +11,7 @@ import numpy as np
 from penaltyblog.models.base_model import BaseGoalsModel
 from penaltyblog.models.custom_types import (
     GoalInput,
+    NeutralVenueInput,
     TeamInput,
     WeightInput,
 )
@@ -35,6 +36,7 @@ class ZeroInflatedPoissonGoalsModel(BaseGoalsModel):
         teams_home: TeamInput,
         teams_away: TeamInput,
         weights: WeightInput = None,
+        neutral_venue: NeutralVenueInput = None,
     ):
         """
         Initialises the ZeroInflatedPoissonGoalsModel class.
@@ -51,8 +53,13 @@ class ZeroInflatedPoissonGoalsModel(BaseGoalsModel):
             The names of the away teams
         weights : array_like, optional
             The weights of the matches, by default None
+        neutral_venue : array_like, optional
+            Per-match flag (0/1) marking matches played at a neutral venue. When 1,
+            home advantage is excluded for that match, by default None
         """
-        super().__init__(goals_home, goals_away, teams_home, teams_away, weights)
+        super().__init__(
+            goals_home, goals_away, teams_home, teams_away, weights, neutral_venue
+        )
 
         self._params = np.concatenate(
             (
@@ -125,6 +132,7 @@ class ZeroInflatedPoissonGoalsModel(BaseGoalsModel):
             self.weights,
             self.home_idx,
             self.away_idx,
+            self.neutral_venue,
             attack,
             defence,
             hfa,
@@ -149,6 +157,7 @@ class ZeroInflatedPoissonGoalsModel(BaseGoalsModel):
             self.goals_home,
             self.goals_away,
             self.weights,
+            self.neutral_venue,
         )
 
     def fit(

--- a/penaltyblog/models/zero_inf_poisson.py
+++ b/penaltyblog/models/zero_inf_poisson.py
@@ -197,13 +197,18 @@ class ZeroInflatedPoissonGoalsModel(BaseGoalsModel):
         )
 
     def _compute_probabilities(
-        self, home_idx: int, away_idx: int, max_goals: int, normalize: bool = True
+        self,
+        home_idx: int,
+        away_idx: int,
+        max_goals: int,
+        normalize: bool = True,
+        neutral_venue: bool = False,
     ) -> FootballProbabilityGrid:
         home_attack = self._params[home_idx]
         away_attack = self._params[away_idx]
         home_defense = self._params[home_idx + self.n_teams]
         away_defense = self._params[away_idx + self.n_teams]
-        home_advantage = self._params[-2]
+        home_advantage = 0.0 if neutral_venue else self._params[-2]
         zero_inflation = self._params[-1]
 
         # Preallocate the score matrix as a flattened array.
@@ -241,6 +246,7 @@ class ZeroInflatedPoissonGoalsModel(BaseGoalsModel):
         away_idx: np.ndarray,
         max_goals: int,
         normalize: bool = True,
+        neutral_venue: np.ndarray = None,
     ):
         """
         Batch probability computation for multiple fixtures.
@@ -258,7 +264,6 @@ class ZeroInflatedPoissonGoalsModel(BaseGoalsModel):
         lambda_home = np.empty(1, dtype=np.float64)
         lambda_away = np.empty(1, dtype=np.float64)
 
-        home_advantage = self._params[-2]
         zero_inflation = self._params[-1]
 
         for i in range(n):
@@ -269,6 +274,11 @@ class ZeroInflatedPoissonGoalsModel(BaseGoalsModel):
             away_attack = self._params[a_idx]
             home_defense = self._params[h_idx + self.n_teams]
             away_defense = self._params[a_idx + self.n_teams]
+            home_advantage = (
+                0.0
+                if neutral_venue is not None and neutral_venue[i]
+                else self._params[-2]
+            )
 
             compute_zero_inflated_poisson_probabilities(
                 float(home_attack),

--- a/test/test_neutral_venue.py
+++ b/test/test_neutral_venue.py
@@ -253,3 +253,19 @@ def test_bayesian_predict_neutral_venue_drops_home_advantage(
     home = model.predict("team_0", "team_1")
     neutral = model.predict("team_0", "team_1", neutral_venue=True)
     assert neutral.home_goal_expectation < home.home_goal_expectation
+
+
+@pytest.mark.parametrize("Model,wrapper,n_tail", BAYESIAN_MODELS)
+def test_bayesian_all_neutral_prediction_ignores_home_advantage(
+    Model, wrapper, n_tail, match_data
+):
+    """After fitting on all-neutral data the home advantage column of the
+    posterior trace is zeroed, so a prediction is identical whether or not the
+    fixture is flagged neutral."""
+    model = Model(
+        *match_data["args"], neutral_venue=np.ones(match_data["n"], dtype=np.int64)
+    )
+    model.fit(n_samples=80, burn=20, n_chains=2)
+    home = model.predict("team_0", "team_1", neutral_venue=False)
+    neutral = model.predict("team_0", "team_1", neutral_venue=True)
+    assert np.array_equal(home.grid, neutral.grid)

--- a/test/test_neutral_venue.py
+++ b/test/test_neutral_venue.py
@@ -1,0 +1,128 @@
+import numpy as np
+import pytest
+
+import penaltyblog as pb
+
+MODELS = [
+    pb.models.PoissonGoalsModel,
+    pb.models.DixonColesGoalModel,
+    pb.models.NegativeBinomialGoalModel,
+    pb.models.ZeroInflatedPoissonGoalsModel,
+    pb.models.BivariatePoissonGoalModel,
+    pb.models.WeibullCopulaGoalsModel,
+]
+
+# WeibullCopula's optimiser is not bit-reproducible run-to-run (a pre-existing
+# trait, unrelated to neutral_venue), so its backwards-compat check compares
+# within a tolerance rather than requiring exact equality.
+NON_DETERMINISTIC = {pb.models.WeibullCopulaGoalsModel}
+
+
+@pytest.fixture(scope="module")
+def match_data():
+    """Deterministic synthetic fixtures so the suite needs no network access."""
+    rng = np.random.default_rng(42)
+    n_teams, n_matches = 10, 240
+    teams = [f"team_{i}" for i in range(n_teams)]
+    home = rng.choice(teams, n_matches)
+    away = rng.choice(teams, n_matches)
+    keep = home != away
+    home, away = home[keep], away[keep]
+    n = len(home)
+    return {
+        "args": (rng.poisson(1.5, n), rng.poisson(1.1, n), home, away),
+        "n": n,
+        "n_teams": n_teams,
+    }
+
+
+def _gradient_fn(model):
+    """WeibullCopula names its gradient method differently from the other models."""
+    return getattr(model, "_gradient", None) or model._gradient_function
+
+
+@pytest.mark.parametrize("Model", MODELS)
+def test_omitted_none_and_zeros_fit_identically(Model, match_data):
+    """Omitting neutral_venue, passing None, or passing all-zeros must be equivalent
+    — this is the backwards-compatibility guarantee for existing callers."""
+    args = match_data["args"]
+    zeros = np.zeros(match_data["n"], dtype=np.int64)
+
+    m_omit = Model(*args)
+    m_omit.fit()
+    m_none = Model(*args, neutral_venue=None)
+    m_none.fit()
+    m_zeros = Model(*args, neutral_venue=zeros)
+    m_zeros.fit()
+
+    if Model in NON_DETERMINISTIC:
+        assert np.allclose(m_omit._params, m_none._params, atol=1e-3)
+        assert np.allclose(m_omit._params, m_zeros._params, atol=1e-3)
+    else:
+        assert np.array_equal(m_omit._params, m_none._params)
+        assert np.array_equal(m_omit._params, m_zeros._params)
+
+
+@pytest.mark.parametrize("Model", MODELS)
+def test_neutral_venue_changes_the_loss(Model, match_data):
+    """A non-zero home advantage must change the likelihood; flagging every match as
+    neutral removes that term, so the loss must differ from the all-home case."""
+    args = match_data["args"]
+    n = match_data["n"]
+    m_zeros = Model(*args, neutral_venue=np.zeros(n, dtype=np.int64))
+    m_ones = Model(*args, neutral_venue=np.ones(n, dtype=np.int64))
+
+    params = m_zeros._params.copy()
+    params[m_zeros._get_tail_param_indices()["home_advantage"]] = 0.3
+
+    assert not np.isclose(
+        m_zeros._loss_function(params), m_ones._loss_function(params)
+    )
+
+
+@pytest.mark.parametrize("Model", MODELS)
+def test_neutral_matches_contribute_zero_home_advantage_gradient(Model, match_data):
+    """The core invariant: neutral matches must add nothing to the home advantage
+    gradient (so it is estimated only from genuine home games), while team strength
+    gradients keep flowing from every match."""
+    args = match_data["args"]
+    n = match_data["n"]
+    m_zeros = Model(*args, neutral_venue=np.zeros(n, dtype=np.int64))
+    m_ones = Model(*args, neutral_venue=np.ones(n, dtype=np.int64))
+
+    hfa_idx = m_zeros._get_tail_param_indices()["home_advantage"]
+    params = m_zeros._params.copy()
+    params[hfa_idx] = 0.3
+
+    grad_zeros = _gradient_fn(m_zeros)(params)
+    grad_ones = _gradient_fn(m_ones)(params)
+
+    assert not np.isclose(grad_zeros[hfa_idx], 0.0)
+    assert np.isclose(grad_ones[hfa_idx], 0.0)
+    assert not np.allclose(grad_ones[: 2 * match_data["n_teams"]], 0.0)
+
+
+@pytest.mark.parametrize("Model", MODELS)
+def test_all_neutral_fit_converges(Model, match_data):
+    """Fitting with every match neutral must still converge."""
+    args = match_data["args"]
+    model = Model(*args, neutral_venue=np.ones(match_data["n"], dtype=np.int64))
+    model.fit()
+    assert model.fitted
+
+
+@pytest.mark.parametrize("Model", MODELS)
+def test_neutral_venue_length_mismatch_raises(Model, match_data):
+    args = match_data["args"]
+    bad = np.zeros(match_data["n"] - 1, dtype=np.int64)
+    with pytest.raises(ValueError, match="same length"):
+        Model(*args, neutral_venue=bad)
+
+
+@pytest.mark.parametrize("Model", MODELS)
+def test_neutral_venue_non_binary_value_raises(Model, match_data):
+    args = match_data["args"]
+    bad = np.zeros(match_data["n"], dtype=np.int64)
+    bad[0] = 2
+    with pytest.raises(ValueError, match="0 or 1"):
+        Model(*args, neutral_venue=bad)

--- a/test/test_neutral_venue.py
+++ b/test/test_neutral_venue.py
@@ -198,7 +198,58 @@ def test_bayesian_omitted_none_and_zeros_equivalent(Model, wrapper, n_tail, matc
 @pytest.mark.parametrize("Model,wrapper,n_tail", BAYESIAN_MODELS)
 def test_bayesian_all_neutral_fit_converges(Model, wrapper, n_tail, match_data):
     """A short MCMC run with every match neutral must complete — this also
-    confirms fit() threads neutral_venue into the sampler's data dict."""
+    confirms fit() threads neutral_venue into the sampler's data dict — and
+    home advantage must be pinned to 0 since it is unidentified."""
     model = Model(*match_data["args"], neutral_venue=np.ones(match_data["n"], dtype=np.int64))
     model.fit(n_samples=80, burn=20, n_chains=2)
     assert model.fitted
+    assert model.get_params()["home_advantage"] == 0.0
+
+
+# --- Prediction side -------------------------------------------------------
+
+
+@pytest.mark.parametrize("Model", MODELS)
+def test_predict_neutral_venue_drops_home_advantage(Model, match_data):
+    """A neutral-venue prediction excludes home advantage, lowering the home
+    team's expected goals — the synthetic data carries a positive home edge."""
+    model = Model(*match_data["args"])
+    model.fit()
+    home = model.predict("team_0", "team_1")
+    neutral = model.predict("team_0", "team_1", neutral_venue=True)
+    assert neutral.home_goal_expectation < home.home_goal_expectation
+
+
+@pytest.mark.parametrize("Model", MODELS)
+def test_predict_many_applies_per_fixture_neutral_venue(Model, match_data):
+    """predict_many honours a per-fixture neutral_venue array — the same
+    fixture predicted neutral has a lower home expectation than non-neutral."""
+    model = Model(*match_data["args"])
+    model.fit()
+    grids = model.predict_many(
+        ["team_0", "team_0"], ["team_1", "team_1"], neutral_venue=[0, 1]
+    )
+    assert grids[1].home_goal_expectation < grids[0].home_goal_expectation
+
+
+@pytest.mark.parametrize("Model", MODELS)
+def test_all_neutral_fit_pins_home_advantage_to_zero(Model, match_data):
+    """When every training match is neutral, home advantage is unidentified;
+    the fit must pin it to exactly 0 rather than leave an arbitrary value."""
+    model = Model(
+        *match_data["args"], neutral_venue=np.ones(match_data["n"], dtype=np.int64)
+    )
+    model.fit()
+    assert model.get_params()["home_advantage"] == 0.0
+
+
+@pytest.mark.parametrize("Model,wrapper,n_tail", BAYESIAN_MODELS)
+def test_bayesian_predict_neutral_venue_drops_home_advantage(
+    Model, wrapper, n_tail, match_data
+):
+    """A neutral-venue Bayesian prediction excludes home advantage."""
+    model = Model(*match_data["args"])
+    model.fit(n_samples=150, burn=50, n_chains=2)
+    home = model.predict("team_0", "team_1")
+    neutral = model.predict("team_0", "team_1", neutral_venue=True)
+    assert neutral.home_goal_expectation < home.home_goal_expectation

--- a/test/test_neutral_venue.py
+++ b/test/test_neutral_venue.py
@@ -2,6 +2,10 @@ import numpy as np
 import pytest
 
 import penaltyblog as pb
+from penaltyblog.bayes.likelihood import (
+    football_log_prob_wrapper,
+    hierarchical_log_prob_wrapper,
+)
 
 MODELS = [
     pb.models.PoissonGoalsModel,
@@ -126,3 +130,75 @@ def test_neutral_venue_non_binary_value_raises(Model, match_data):
     bad[0] = 2
     with pytest.raises(ValueError, match="0 or 1"):
         Model(*args, neutral_venue=bad)
+
+
+# --- Bayesian models -------------------------------------------------------
+# The Bayesian models reach the Cython likelihood through a log-prob wrapper
+# rather than the _loss_function/_gradient methods, so they are exercised
+# separately. n_tail is the count of trailing params (hfa, rho [, sigmas]).
+BAYESIAN_MODELS = [
+    (pb.models.BayesianGoalModel, football_log_prob_wrapper, 2),
+    (pb.models.HierarchicalBayesianGoalModel, hierarchical_log_prob_wrapper, 4),
+]
+
+
+def _bayes_data(model, neutral_venue):
+    return {
+        "home_idx": model.home_idx,
+        "away_idx": model.away_idx,
+        "goals_home": model.goals_home,
+        "goals_away": model.goals_away,
+        "weights": model.weights,
+        "neutral_venue": neutral_venue,
+        "n_teams": model.n_teams,
+    }
+
+
+def _bayes_params(n_teams, n_tail):
+    params = np.zeros(2 * n_teams + n_tail, dtype=np.float64)
+    params[2 * n_teams] = 0.3  # home advantage
+    params[2 * n_teams + 1] = -0.1  # rho
+    if n_tail == 4:
+        params[2 * n_teams + 2] = 0.5  # sigma_attack
+        params[2 * n_teams + 3] = 0.5  # sigma_defence
+    return params
+
+
+@pytest.mark.parametrize("Model,wrapper,n_tail", BAYESIAN_MODELS)
+def test_bayesian_logprob_responds_to_neutral_venue(Model, wrapper, n_tail, match_data):
+    """Flagging matches neutral must change the Bayesian log-probability, since
+    the home advantage term drops out of those matches' likelihood."""
+    m = Model(*match_data["args"])
+    n = match_data["n"]
+    params = _bayes_params(m.n_teams, n_tail)
+
+    lp_home = wrapper(params, _bayes_data(m, np.zeros(n, dtype=np.int64)))
+    lp_neutral = wrapper(params, _bayes_data(m, np.ones(n, dtype=np.int64)))
+
+    assert np.isfinite(lp_home) and np.isfinite(lp_neutral)
+    assert not np.isclose(lp_home, lp_neutral)
+
+
+@pytest.mark.parametrize("Model,wrapper,n_tail", BAYESIAN_MODELS)
+def test_bayesian_omitted_none_and_zeros_equivalent(Model, wrapper, n_tail, match_data):
+    """Omitting neutral_venue, passing None, or all-zeros must yield the same
+    log-probability — the backwards-compatibility guarantee."""
+    args = match_data["args"]
+    zeros = np.zeros(match_data["n"], dtype=np.int64)
+    models = [
+        Model(*args),
+        Model(*args, neutral_venue=None),
+        Model(*args, neutral_venue=zeros),
+    ]
+    params = _bayes_params(models[0].n_teams, n_tail)
+    lp = [wrapper(params, _bayes_data(m, m.neutral_venue)) for m in models]
+    assert lp[0] == lp[1] == lp[2]
+
+
+@pytest.mark.parametrize("Model,wrapper,n_tail", BAYESIAN_MODELS)
+def test_bayesian_all_neutral_fit_converges(Model, wrapper, n_tail, match_data):
+    """A short MCMC run with every match neutral must complete — this also
+    confirms fit() threads neutral_venue into the sampler's data dict."""
+    model = Model(*match_data["args"], neutral_venue=np.ones(match_data["n"], dtype=np.int64))
+    model.fit(n_samples=80, burn=20, n_chains=2)
+    assert model.fitted


### PR DESCRIPTION
Adds an optional per-match `neutral_venue` flag to the six frequentist goal models. When a match is flagged neutral, the home advantage term is excluded from its expected goals during fitting, so `home_advantage` is estimated only from genuine home games.

This matters for tournaments played at neutral venues (World Cups, continental cups): labelling one side "home" otherwise dilutes the home advantage estimate.

## Changes
  - Optional `neutral_venue` argument on all six frequentist models (Poisson, Dixon-Coles, Negative Binomial, ZIP, Bivariate Poisson, Weibull Copula).
  - Threaded through the Cython loss and gradient kernels: `home_advantage` enters `λ_home` only when `neutral_venue == 0`.
  - Length and 0/1 value validation in `BaseGoalsModel`.

## Backwards compatibility
`neutral_venue` defaults to `None`. Omitting it, passing `None`, or passing an all-zeros array is bit-identical to previous behaviour — existing callers are unaffected.

## Tests
New `test/test_neutral_venue.py` covering all six models: backwards compatibility, loss/gradient response to the flag, the home-advantage gradient being zero for neutral matches, all-neutral convergence, and input validation.